### PR TITLE
20240207 update

### DIFF
--- a/aur-repo/artery-isp-console-bin/PKGBUILD
+++ b/aur-repo/artery-isp-console-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: taotieren <admin@taotieren.com>
 
 pkgname=artery-isp-console-bin
-pkgver=3.0.09
+pkgver=3.0.10
 pkgrel=2
 # epoch=1
 pkgdesc="Artery ISP Console 是一款基于 MCU Bootloader 的命令行应用程序。使用该应用程序,用户可以通过 UART 端口或者 USB 端口配置操作 Artery 的 MCU 设备。"
@@ -37,7 +37,7 @@ install=${pkgname}.install
 _pkg_file_name=Artery_ISP_Console_Linux-${arch}_V${pkgver}.zip
 source=("${_pkg_file_name}::https://www.arterytek.com/download/TOOL/Artery_ISP_Console_Linux-${arch}_V${pkgver}.zip"
     ${pkgname}.install)
-sha256sums=('b634f872ca00145163c4d4c3fb9e9967f60b3ab35487f3ee0dadefab53ff2ba6'
+sha256sums=('f8ba929f65974da0b03b9d2019327f3f958e26e5371683e968845c7f63f90afe'
             'a5c4d923298e09eef75b9481ea4fd83998d01c1d3605f118edd42f89ee17e619')
 noextract=()
 


### PR DESCRIPTION
不好意思大佬能是否維護一下
1. at32-work-bench
    * 能是否拿掉"目前仅支持 AT32F421 系列"的部分，官方己適配大部分AT32的MCU(來源: 官網）
       ![圖片](https://github.com/taotieren/aur-repo/assets/54382007/a0c4d58a-eb96-42ec-918f-aed5e5926b00)

2.  artery-isp-console-bin
     * 能是否更新來源連結