### PR TITLE
update mounriverstudio to 230 & switch to dynamic download via API

### DIFF
--- a/aur-repo/mounriverstudio-bin/PKGBUILD
+++ b/aur-repo/mounriverstudio-bin/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: taotieren <admin@taotieren.com>
+# Contributor: t3u <t3u@t3u.uk>
 
 pkgbase=mounriverstudio-bin
 pkgname=(${pkgbase})
@@ -46,7 +47,7 @@ depends=(
     # AUR
     #     ncurses5-compat-libs
 )
-makedepends=('tar')
+makedepends=('tar' 'jq' 'curl')
 optdepends=('ch34x-dkms-git: CH341SER driver with fixed bug'
     'i2c-ch341-dkms: CH341 USB-I2C adapter driver'
     'spi-ch341-usb-dkms: SPI/GPIO driver for CH341'
@@ -59,29 +60,105 @@ optdepends=('ch34x-dkms-git: CH341SER driver with fixed bug'
     "imsprog: MSProg - software for CH341A-based programmers to work with I2C, SPI and MicroWire EEPROM/Flash chips"
     "sfp-master: SFP-module programmer for CH341a devices"
 )
-_sign="?sign=c5604eb8218c9e25c4a33e1169b5f59f&time=19b11b2ce25&from=211.7.96.64&resId=1987838612315652097"
-source=("${pkgbase}-${pkgver}.deb::https://file-oss.mounriver.com/upgrade/MounRiverStudio_Linux_X64_V${pkgver}.deb${_sign}")
-sha256sums=('31358a6af0c2be722f5b50f9d490005e15942f67fb106ab002e8ea2cb8540b78')
+source=()
+sha256sums=()
 options=('!strip' '!debug')
-# noextract=(${pkgbase}-${pkgver}.deb)
+
+# automatic version detection & download via MounRiver API
+prepare() {
+    msg "Querying MounRiver API for the latest Linux version..."
+    local _info_json=$(curl -s "https://api.mounriver.com/mountriver/api/version/fetchRecent?swType=2&osType=LINUX&lang=en")
+    
+    local _soft_id=$(echo "${_info_json}" | jq -r '.result.softId')
+    local _filename=$(echo "${_info_json}" | jq -r '.result.softFileName')
+    local _api_version=$(echo "${_info_json}" | jq -r '.result.version')
+
+    if [[ "${_soft_id}" == "null" || -z "${_soft_id}" ]]; then
+        error "Failed to retrieve software ID from API."
+        return 1
+    fi
+
+    msg "Found Version: ${_api_version} (File: ${_filename}, ID: ${_soft_id})"
+
+    msg "Fetching dynamic download link..."
+    local _dl_json=$(curl -s "https://api.mounriver.com/mountriver/api/version/getDownloadUrl?resourceId=${_soft_id}")
+    local _dl_url=$(echo "${_dl_json}" | jq -r '.data // .result')
+
+    if [[ "${_dl_url}" == "null" || -z "${_dl_url}" || "${_dl_url}" != http* ]]; then
+        error "Failed to retrieve valid download URL."
+        return 1
+    fi
+
+    if [ ! -f "${_filename}" ]; then
+        msg "Downloading ${_filename}..."
+        curl -L -o "${_filename}" "${_dl_url}"
+    else
+        msg "File ${_filename} already exists, skipping download."
+    fi
+
+    # Cleanup old extraction
+    local _old_dir=$(find . -maxdepth 1 -mindepth 1 -type d -print -quit)
+    if [ -n "$_old_dir" ]; then
+        rm -rf "$_old_dir"
+    fi
+
+    msg "Extracting ${_filename}..."
+    tar -xf "${_filename}"
+}
 
 package() {
-    tar -xf "${srcdir}//data.tar.xz" -C "${pkgdir}/"
-    find "${pkgdir}/" -type d -exec chmod 755 {} \;
-    find ${pkgdir}/usr/share/MRS2 -perm 600 -exec chmod 644 {} \;
+    cd "${srcdir}/"
 
-    cd ${pkgdir}/usr/share/
-    sed -i 's|/usr/share/MRS2/MRS-linux-x64/mounriver-studio\\ 2|mounriverstudio|g' applications/MounRiverStudio2.desktop
-    cd MRS2
-    sed -i 's|plugdev|uucp|g' beforeinstall/50-wch.rules
-    sed -i 's|plugdev|uucp|g' beforeinstall/60-openocd.rules
-    install -Dm0644 "beforeinstall/50-wch.rules" "${pkgdir}/usr/lib/udev/rules.d/50-mrs2.rules"
-    install -Dm0644 "beforeinstall/60-openocd.rules" "${pkgdir}/usr/lib/udev/rules.d/60-openocd-mrs2.rules"
-    install -Dm0755 "beforeinstall/load.sh" "${pkgdir}/usr/bin/${pkgname%-bin}"
-    rm -rf beforeinstall
-    sed -i 's|plugdev|uucp|g' MRS-linux-x64/resources/app/resources/linux/components/WCH/Others/CommunicationLib/default/50-wch.rules
-    sed -i 's|plugdev|uucp|g' MRS-linux-x64/resources/app/resources/linux/components/WCH/Others/CommunicationLib/default/60-openocd.rules
+    local _extracted_dir=$(find . -maxdepth 1 -mindepth 1 -type d -print -quit)
+    if [[ -z "${_extracted_dir}" ]]; then
+        error "Extracted directory not found!"
+        return 1
+    fi
 
+    msg "Installing from: ${_extracted_dir}"
+
+    mkdir -p "${pkgdir}/usr/share"
+    cp -r "${_extracted_dir}" "${pkgdir}/usr/share/MRS2"
+
+    msg "Fixing permissions..."
+    find "${pkgdir}/usr/share/MRS2" -type d -exec chmod 755 {} \;
+    find "${pkgdir}/usr/share/MRS2" -perm 600 -exec chmod 644 {} \;
+
+    cd "${pkgdir}/usr/share/MRS2"
+    if [ -d "beforeinstall" ]; then
+        msg "Installing udev rules..."
+        sed -i 's|plugdev|uucp|g' beforeinstall/50-wch.rules
+        sed -i 's|plugdev|uucp|g' beforeinstall/60-openocd.rules
+        install -Dm0644 "beforeinstall/50-wch.rules" "${pkgdir}/usr/lib/udev/rules.d/50-mrs2.rules"
+        install -Dm0644 "beforeinstall/60-openocd.rules" "${pkgdir}/usr/lib/udev/rules.d/60-openocd-mrs2.rules"
+
+        install -Dm0755 "beforeinstall/load.sh" "${pkgdir}/usr/bin/${pkgname%-bin}"
+    fi
+
+    local _res_path="MRS-linux-x64/resources/app/resources/linux/components/WCH/Others/CommunicationLib/default"
+    if [ -d "${_res_path}" ]; then
+        sed -i 's|plugdev|uucp|g' ${_res_path}/50-wch.rules
+        sed -i 's|plugdev|uucp|g' ${_res_path}/60-openocd.rules
+    fi
+
+    msg "Generating Desktop Entry..."
+    local _icon_src="MRS-linux-x64/resources/app/resources/linux/code.png"
+    if [ -f "${_icon_src}" ]; then
+        install -Dm644 "${_icon_src}" "${pkgdir}/usr/share/pixmaps/MounRiverStudio2.png"
+    fi
+
+    install -Dm644 /dev/stdin "${pkgdir}/usr/share/applications/mounriverstudio.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=MounRiver Studio Ⅱ
+Exec=bash "/usr/share/MRS2/beforeinstall/load.sh" %F
+Icon=MounRiverStudio2
+MimeType=application/x-mrs-project;
+Comment=MounRiver Stduio Ⅱ is a free integrated development environment for embedded MCU.
+Categories=TextEditor;Development;IDE;
+EOF
+
+    msg "Creating OpenOCD wrappers..."
     install -Dm0755 /dev/stdin "${pkgdir}/usr/bin/openocd-mrs2-arm" <<EOF
 #!/bin/env bash
 exec /usr/share/MRS2/MRS-linux-x64/resources/app/resources/linux/components/WCH/OpenOCD/OpenOCD/bin/openocd -f /usr/share/MRS2/MRS-linux-x64/resources/app/resources/linux/components/WCH/OpenOCD/OpenOCD/bin/wch-arm.cfg "\$@"

--- a/aur-repo/mounriverstudio-bin/lilac.yaml
+++ b/aur-repo/mounriverstudio-bin/lilac.yaml
@@ -11,4 +11,4 @@ post_build_script: |
 update_on:
   - source: regex
     url: http://api.mounriver.com/mountriver/api/version/fetchRecent2?swType=2&osType=LINUX&lang=zh
-    regex: 'MounRiverStudio_Linux_X64_V([\d.]+).deb'
+    regex: 'softFileName":"MounRiverStudio_Linux_X64_V(\d+)\.tar\.xz'


### PR DESCRIPTION
Upstream uses short-lived signed URLs, so downloading dynamically via API avoids frequent breakage.