### PR TITLE
mounriverstudio-bin: fix broken desktop entry

### DIFF
--- a/aur-repo/mounriverstudio-bin/PKGBUILD
+++ b/aur-repo/mounriverstudio-bin/PKGBUILD
@@ -158,7 +158,7 @@ package() {
 [Desktop Entry]
 Type=Application
 Name=MounRiver Studio Ⅱ
-Exec=bash "/usr/share/MRS2/beforeinstall/load.sh" %F
+Exec=/usr/bin/${pkgname%-bin} %F
 Icon=MounRiverStudio2
 MimeType=application/x-mrs-project;
 Comment=MounRiver Stduio Ⅱ is a free integrated development environment for embedded MCU.


### PR DESCRIPTION
Fixed the Exec path in the .desktop file which was preventing the application from launching correctly in the previous version.